### PR TITLE
Filter for drawio files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,7 +13,7 @@
     + Remove blank lines
   entry: lxml_format
   language: python
-  types: [xml]
+  files: \.drawio$
   stages:
     - pre-commit
     - pre-merge-commit


### PR DESCRIPTION
Modified file filter for the hook to run on all drawio files.

Replaced the filter "types" by "files" and used regex to pass hook to all files with extension draw.io

Tested with local modification in System-Eng-Architecture repo. Passed with --all-files flag and all .drawio files were modified, see below.

![image](https://github.com/user-attachments/assets/1a33573e-6af4-4e73-bc2f-7b8e56518079)
